### PR TITLE
Add common host settings role for Ansible

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@
 VM 払い出し後の初期化は `scripts/bootstrap-ansible-user.sh` を利用する。
 手順の詳細は `scripts/bootstrap-ansible-user.md` を参照する。
 
+## Common Host Settings
+
+共通ホスト設定は `ansible/playbooks/site.yml` から `ansible/roles/common` を適用する。
+ホストごとの差分は `ansible/inventories/*/host_vars/<host>.yml` に置く。
+詳細は `ansible/roles/common/README.md` を参照する。
+
 ## Phase
 
 - Phase 1: controlplane を構築する

--- a/ansible/.ansible-lint
+++ b/ansible/.ansible-lint
@@ -1,5 +1,2 @@
 ---
-# 一時的に空のエントリポイント playbook を lint 対象から除外する
-# playbooks/site.yml に実際の play を実装したら、この exclude を見直すこと
-exclude_paths:
-  - playbooks/site.yml
+exclude_paths: []

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ./roles

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -1,3 +1,8 @@
 ---
-# 下記は例です
-# - import_playbook: prepare-nodes.yml
+- name: Apply common host settings
+  hosts: all
+  become: true
+  gather_facts: true
+
+  roles:
+    - role: common

--- a/ansible/roles/common/README.md
+++ b/ansible/roles/common/README.md
@@ -1,0 +1,30 @@
+# common role
+
+共通ホスト設定を適用する。
+
+対象:
+
+- ホスト名
+- タイムゾーン
+- 基本パッケージ
+- ユーザ作成
+- sudo グループ付与
+- authorized_keys 配置
+- swap 無効化
+
+例:
+
+```yaml
+common_hostname: "cp01"
+common_users:
+  - name: ansible
+    comment: "Ansible automation user"
+    sudo: true
+    authorized_keys:
+      - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGexample ansible@example"
+```
+
+メモ:
+
+- `common_timezone` の既定値は `Asia/Tokyo`
+- 作成するユーザのログインシェルは `/bin/bash`

--- a/ansible/roles/common/defaults/main.yml
+++ b/ansible/roles/common/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+common_hostname: ""
+common_timezone: "Asia/Tokyo"
+# Define per-host users in host_vars, for example:
+# common_users:
+#   - name: ansible
+#     comment: "Ansible automation user"
+#     sudo: true
+#     authorized_keys:
+#       - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGexample ansible@example"
+common_users: []

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,0 +1,130 @@
+---
+- name: Validate common role inputs
+  ansible.builtin.assert:
+    that:
+      - common_hostname is defined
+      - common_hostname is string
+      - common_hostname | length > 0
+    fail_msg: "common_hostname must be defined as a non-empty string for each host."
+    quiet: true
+
+- name: Validate common_users entries
+  ansible.builtin.assert:
+    that:
+      - item.name is defined
+      - item.name is string
+      - item.name | length > 0
+      - item.comment is not defined or item.comment is string
+      - item.sudo is defined
+      - item.sudo | type_debug == "bool"
+      - item.authorized_keys is not defined or item.authorized_keys | type_debug == "list"
+    fail_msg: "Each common_users entry must define name and sudo. comment and authorized_keys are optional."
+    quiet: true
+  loop: "{{ common_users }}"
+  loop_control:
+    label: "{{ item.name | default('undefined') }}"
+
+- name: Validate common_users authorized_keys entries
+  # common_users に定義された全ユーザについて、authorized_keys がある場合だけ 1 件ずつ検証する。
+  # query('subelements', ...) のループ要素は [user, authorized_key] なので、item.1 が公開鍵。
+  # authorized_keys を省略したり空リストにするのは許容するが、指定した各公開鍵に空文字は許容しない。
+  ansible.builtin.assert:
+    that:
+      - item.1 is string
+      - item.1 | length > 0
+    fail_msg: "Each authorized_keys entry must be a non-empty string."
+    quiet: true
+  loop: "{{ query('subelements', common_users, 'authorized_keys', {'skip_missing': True}) }}"
+  loop_control:
+    label: "{{ item.0.name }}"
+
+- name: Set hostname
+  ansible.builtin.hostname:
+    name: "{{ common_hostname }}"
+    use: systemd
+
+- name: Set timezone
+  community.general.timezone:
+    name: "{{ common_timezone }}"
+
+- name: Install basic packages
+  ansible.builtin.apt:
+    name:
+      - ca-certificates
+      - curl
+      - gnupg
+    state: present
+
+- name: Ensure managed users exist
+  ansible.builtin.user:
+    name: "{{ item.name }}"
+    comment: "{{ item.comment | default(omit) }}"
+    shell: /bin/bash # ここでは全ユーザ共通で /bin/bash を指定する
+    create_home: true
+    state: present
+  loop: "{{ common_users }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Ensure sudo users belong to sudo group
+  ansible.builtin.user:
+    name: "{{ item.name }}"
+    groups: sudo
+    append: true
+    state: present
+  loop: "{{ common_users | selectattr('sudo') | list }}" # Debian 13 下 では wheel ではなく sudo group
+  loop_control:
+    label: "{{ item.name }}"
+
+# TODO: 必要に応じて sudo グループの剥奪を実装する
+
+- name: Install authorized_keys for managed users
+  ansible.posix.authorized_key:
+    user: "{{ item.0.name }}"
+    key: "{{ item.1 }}"
+    state: present
+    manage_dir: true # ~/.ssh を管理
+  loop: "{{ query('subelements', common_users, 'authorized_keys', {'skip_missing': True}) }}"
+  loop_control:
+    label: "{{ item.0.name }}"
+
+- name: Manage swap settings
+  block:
+    - name: Collect active swap devices
+      ansible.builtin.command:
+        argv:
+          - swapon
+          - --show=NAME
+          - --noheadings
+          - --raw
+      register: common_active_swap
+      changed_when: false
+
+    - name: Disable active swap
+      ansible.builtin.command:
+        argv:
+          - swapoff
+          - -a
+      when: common_active_swap.stdout | trim != ""
+      changed_when: true
+
+    - name: Collect swap entries from fstab
+      ansible.builtin.command:
+        argv:
+          - awk
+          - '($1 !~ /^#/ && $3 == "swap") {print $1 "\t" $2 "\t" $3}'
+          - /etc/fstab
+      register: common_fstab_swap_entries
+      changed_when: false
+
+    - name: Remove swap entries from fstab
+      ansible.posix.mount:
+        path: "{{ item_fields[1] }}"
+        src: "{{ item_fields[0] }}"
+        fstype: "{{ item_fields[2] }}"
+        state: absent_from_fstab
+      loop: "{{ common_fstab_swap_entries.stdout_lines }}"
+      loop_control:
+        label: "{{ item_fields[0] }}"
+      vars:
+        item_fields: "{{ item.split('\t') }}"


### PR DESCRIPTION
## 概要
- common role を追加し、ホスト名、タイムゾーン、ユーザ作成、swap 無効化を Ansible で適用できるようにしました
- host_vars で使う変数例と確認手順のドキュメントを追加しました
- site.yml を lint 対象に戻し、roles_path を ansible.cfg で明示しました

## 変更内容
- `ansible/playbooks/site.yml` から `common` role を適用
- `ansible/roles/common` に defaults と tasks を追加
- `common_hostname`、`common_timezone`、`common_users`、`common_disable_swap` を公開インタフェースとして定義

#22 の対応